### PR TITLE
fix mean of widths for avg_width

### DIFF
--- a/openpecha/formatters/ocr/google_vision.py
+++ b/openpecha/formatters/ocr/google_vision.py
@@ -138,9 +138,13 @@ class GoogleVisionFormatter(OCRFormatter):
                         cur_word = ""
                         bbox = self.dict_to_bbox(word)
                         bboxes.append(bbox)
-        avg_width = statistics.mean(widths)
+        if widths:
+            avg_width = statistics.mean(widths)
+        else:
+            avg_width = 0
         logging.debug("average char width: %f", avg_width)
         return bboxes, avg_width
+
 
     def get_bboxes_for_page(self, image_group_id, image_filename):
         ocr_object = self.data_provider.get_image_data(image_group_id, image_filename)


### PR DESCRIPTION
- fix the get_char_base_bboxes_and_avg_width function. Return avg_width as 0 if widths list is empty.

Input to recreate the bug:
   [I1PD958530003.json.gz](https://github.com/OpenPecha/Toolkit/files/9899690/I1PD958530003.json.gz)
