### PR TITLE
fix bbox get_height and get_width

### DIFF
--- a/openpecha/formatters/ocr/ocr.py
+++ b/openpecha/formatters/ocr/ocr.py
@@ -52,10 +52,12 @@ class BBox:
         self.mid_x = (x1 + x2) / 2
     
     def get_height(self):
-        return self.y2 - self.y1
+        return abs(self.y2 - self.y1)
 
     def get_width(self):
-        return self.x2 - self.x1
+        if self.x2 == self.x1:
+            self.x2 += 1
+        return abs(self.x2 - self.x1)
     
     def get_box_orientation(self):
         width = self.x2 - self.x1


### PR DESCRIPTION
- value of get_width and get_height are absolute to not get negative value of height and width
- if side boundaries are overlapping, we return get_width value as 1

Input to recreate the bug:
[06150003.json.gz](https://github.com/OpenPecha/Toolkit/files/9899828/06150003.json.gz)
[06190003.json.gz](https://github.com/OpenPecha/Toolkit/files/9899831/06190003.json.gz)
