### PR TITLE
Fix pecha publish branch and base_names_list

### DIFF
--- a/openpecha/core/pecha.py
+++ b/openpecha/core/pecha.py
@@ -449,7 +449,7 @@ class OpenPechaGitRepo(OpenPechaFS):
         self._opf_path = self.pecha_path / f"{self.pecha_id}.opf"
         return self._opf_path
 
-    def publish(self, asset_path: Path = None, asset_name: str = None):
+    def publish(self, asset_path: Path = None, asset_name: str = None, branch: str = "main"):
         asset_paths = []
         if not self.storage:
             self.storage = GithubStorage()
@@ -458,7 +458,7 @@ class OpenPechaGitRepo(OpenPechaFS):
             commit_and_push(repo=local_repo, message="Pecha update")
         else:
             self.storage.add_dir(
-                path=self.pecha_path, description=self.about, is_private=self.is_private
+                path=self.pecha_path, description=self.about, is_private=self.is_private, branch=branch
             )
 
         # Publishing assets in release

--- a/openpecha/storages.py
+++ b/openpecha/storages.py
@@ -1,9 +1,9 @@
 import enum
-import git
 import os
 import shutil
 from pathlib import Path
 
+import git
 from git import Repo
 from github import Github
 
@@ -130,15 +130,15 @@ class GithubStorage(Storage):
             _ = git.Repo(path).git_dir
             return True
         except git.exc.InvalidGitRepositoryError:
-            return False       
+            return False
 
-    def add_dir(self, path: Path, description: str, is_private: bool=False):
+    def add_dir(self, path: Path, description: str, is_private: bool = False, branch: str = "master"):
         """dir local dir to github."""
         remote_repo_url = self._init_remote_repo(
             path=path, description=description, is_private=is_private
         )
         local_repo = self._init_local_repo(path=path, remote_url=remote_repo_url)
-        commit_and_push(repo=local_repo, message="Initial commit")
+        commit_and_push(repo=local_repo, message="Initial commit", branch=branch)
         return local_repo
 
     def remove_dir_with_name(self, name: str):

--- a/tests/core/test_pecha.py
+++ b/tests/core/test_pecha.py
@@ -193,3 +193,8 @@ def test_multi_create_pecha():
 
     assert len(pecha_02.bases) == 1
     assert pecha_02.bases[pecha_02_base_name] == "pecha_02 base content"
+
+
+def test_pecha_base_names_list(opf_path):
+    pecha = OpenPechaFS(path=opf_path)
+    assert pecha.base_names_list == ["v001"]


### PR DESCRIPTION
- `pecha.publish` now accepts `branch` optional arg, default to `main`.
- access base names before loading base and layers with `pecha.base_names_list` atrr.